### PR TITLE
画像がない記事をスキップする

### DIFF
--- a/system/app.py
+++ b/system/app.py
@@ -125,6 +125,10 @@ def api_suggest_news():
             data = json.loads(req.text)
 
         for datum in data['channel']['item']:
+            # 画像がない記事は飛ばす
+            if datum['imgPath']=='':
+                continue
+
             news_list.append({
                     'url'    : (url := f'{base_url}/news/{datum["link"]}'),
                     'title'  : datum['title'],


### PR DESCRIPTION
## 関連issue
#1 

## やったこと
`/api/suggest-news`で、画像がない記事をフロント側に返さないように修正

## UI(スクショなどあれば)
変更前
<img width="500" alt="スクリーンショット 2021-10-23 13 11 50" src="https://user-images.githubusercontent.com/61813626/138543272-56fb48e8-2238-44af-b86d-153b07abc3e3.png">

変更後
<img width="400" alt="スクリーンショット 2021-10-23 14 06 54" src="https://user-images.githubusercontent.com/61813626/138543277-df7a102c-bdc1-4f11-854a-62cddc54c592.png">
