### PR TITLE
ニュース登録時にzoom_idを送信する

### DIFF
--- a/system/static/js/app.js
+++ b/system/static/js/app.js
@@ -76,6 +76,7 @@ var vmNews = new Vue({
     news_list: [],
     range_end: 6,
     range_shift: 6,
+    zoom_id: "",
   },
   computed: {
     newsSuggest: function () {
@@ -91,6 +92,10 @@ var vmNews = new Vue({
     },
     // 選んだニュースを送信し保存
     newsSave: function () {
+      if (this.zoom_id === "") {
+        window.alert("zoom idを入力してください");
+        return;
+      }
       for (let i = 0; i < this.news_list.length; ++i) {
         news = this.news_list[i];
         console.log(news.is_wanted);
@@ -101,6 +106,7 @@ var vmNews = new Vue({
               news_id: news.news_id,
               title: news.title,
               imgsrc: news.imgsrc,
+              zoom_id: this.zoom_id,
             })
             .then((response) => {
               this.result = response.data.status;

--- a/system/templates/news.html
+++ b/system/templates/news.html
@@ -10,6 +10,7 @@
   <body>
     [% include "html/header.html" %]
     <div id="news">
+      <h2>zoom idを入力してください: <input type="text" v-model="zoom_id" placeholder="xxx xxxx xxxx"></h2>
       <h2 v-model="newsSuggest">質問に入れたいニュースページを選んでください</h2>
       <div id="wanted-news-list-wrapper">
         <wanted-news-list v-for="(news, ix) in news_list" v-if="ix<range_end" :key="news.news_id" :news="news" @is_wanted="(is_wanted) => news.is_wanted=is_wanted"></wanted-news-list>


### PR DESCRIPTION
## 関連issue
#9 

## やったこと
- ニュース登録ページ(/news)にzoom_idを入力するフォームを作った
- サーバー側に、選んだニュースに加えて、zoom_idも送信 (zoom_idが入力されていない場合は、ポップアップを出す)

## UI(スクショなどあれば)
/newsの画面
<img width="800" alt="スクリーンショット 2021-10-27 20 01 50" src="https://user-images.githubusercontent.com/61813626/139053640-447e4f9f-0ebb-4f65-b10d-1ade0d3b4023.png">