### PR TITLE
/api/save-newsでzoom_idを含めてデータベースに保存する

### DIFF
--- a/system/app.py
+++ b/system/app.py
@@ -176,20 +176,12 @@ def api_save_news():
     zoom_id = request.json['zoom_id']
     print(f'{news=}')
 
+    news_od = db.child('news').get().val()
     settled = False # news_idとzoom_idの組が一致するデータが存在するかのフラグ
 
-    try:
-        news_od = db.child('news')\
-                .order_by_child('news_id')\
-                .equal_to(news.news_id)\
-                .get().val()
-    except IndexError:
-        pass # 該当のnews_idのデータがないのでFalseのまま
-    else:
-        # 該当のnews_idのデータがある場合、そのデータの中に該当のzoom_idのデータが存在するかチェック
-        for value in news_od.values():
-            if 'zoom_id' in value and value['zoom_id'] == zoom_id:
-                settled = True
+    for value in news_od.values():
+        if value['news_id'] == news.news_id and 'zoom_id' in value and value['zoom_id'] == zoom_id:
+            settled = True
 
     # データを追加する
     if not settled:

--- a/system/app.py
+++ b/system/app.py
@@ -199,11 +199,11 @@ def api_save_news():
         print('saving news....')
 
         return {'status': 'SAVED'}
-    # データを追加しない
-    else:
-        print(f'the news already settled. <{news_od=}>')
 
-        return {'status': 'ALREADY SETTLED'}
+    # データを追加しない
+    print(f'the news already settled. <{news_od=}>')
+
+    return {'status': 'ALREADY SETTLED'}
 
 
 @deco_api


### PR DESCRIPTION
## 関連issue
#9 

## やったこと
`/api/save-news`でフロントから受け取ったzoom_idも含めてデータベースに保存するように変更しました。その際、news_idとzoom_idの組が一致するデータが存在しない場合は`{'status': 'SAVED'}`、存在する場合は`{'status': 'ALREADY SETTLED'}`を返す、という風に修正しています。

## 備考
news_idとzoom_idの組が一致するデータが存在するか判定するために、以下のようなコードを書いたのですが、上手く動きませんでした。
```python
news_od = db.child('news')\
            .order_by_child('news_id')\
            .equal_to(news.news_id)\
            .order_by_child('zoom_id')\
            .equal_to(zoom_id)\
            .get().val()
```
このコードだと、zoom_idが一致するものしか取れないみたいです。Pyrebaseのドキュメントも読んだんですが、複数のカラムで検索するやり方が分からず、結局このPRのコードになってしまったのですが、何かやり方を知ってたら教えて欲しいです。

## 参考資料
- [thisbejim / Pyrebase](https://github.com/thisbejim/Pyrebase)
