### PR TITLE
興味のあるニュースの取得処理の修正

### DIFF
--- a/system/app.py
+++ b/system/app.py
@@ -292,28 +292,18 @@ def api_save_speech():
 def get_interest_df(zoom_id: str):
     """ 興味のあるニュースを取得する """
 
-    # ルーム参加者の名前を全件取得
-    names = db.child('room')\
-            .order_by_child('zoom_id')\
-            .equal_to(zoom_id)\
-            .get().to_df()['name']
-    print('names=')
-    print(names)
-
-    # ルーム参加者全員の中で最も人気があるニュースを持ってくる
+    # 該当のzoom_idで興味を持たれたニュースを取得
     interest_df = pd.DataFrame(index=[], columns=['name', 'news_id', 'degree'])
-    for name in names:
-        try:
-            _interest_df = db.child('interest')\
-                    .order_by_child('name')\
-                    .equal_to(name)\
-                    .get().to_df()
-        except:
-            continue
-
+    try:
+        _interest_df = db.child('interest')\
+                .order_by_child('zoom_id')\
+                .equal_to(zoom_id)\
+                .get().to_df()
+    except:
+        pass
+    else:
         interest_df = pd.concat([interest_df, _interest_df])
-
-    interest_df['degree'] = interest_df['degree'].astype(int)
+        interest_df['degree'] = interest_df['degree'].astype(int)
 
     return interest_df
 

--- a/system/app.py
+++ b/system/app.py
@@ -231,32 +231,25 @@ def api_save_degree():
     payload  = {key: request.json[key] for key in [
             'name',
             'news_id',
-            'degree'
+            'degree',
+            'zoom_id'
         ]}
 
     interest = Interest.from_dict(payload)
     print(f'{interest=}')
 
-    try:
-        interest_od = db.child('interest')\
-                .order_by_child('news_id')\
-                .equal_to(interest.news_id)\
-                .get().val()
+    interest_od = db.child('interest').get().val()
 
-    # ニュースがない場合は追加
-    except IndexError:
-        db.child('interest').push(interest.to_dict())
-        print('saving interest....')
+    for key, value in interest_od.items():
+        if value['news_id'] == interest.news_id and 'zoom_id' in value and value['zoom_id'] == interest.zoom_id and value['name'] == interest.name:
+            # news_id, zoom_id, nameが一致するデータが存在するなら、データを追加しない
+            return {'status': 'ALREADY SETTLED'}
 
-        return {'status': 'SAVED'}
+    # データを追加する
+    db.child('interest').push(interest.to_dict())
+    print('saving interest....')
 
-    # ニュースがある場合は追加しない
-    else:
-        k = list(interest_od.keys())[0]
-        db.child('interest').child(k).update(interest.to_dict())
-        print('updating interest....')
-
-        return {'status': 'UPDATED'}
+    return {'status': 'SAVED'}
 
 
 @deco_api

--- a/system/app.py
+++ b/system/app.py
@@ -241,7 +241,9 @@ def api_save_degree():
     interest_od = db.child('interest').get().val()
 
     for key, value in interest_od.items():
-        if value['news_id'] == interest.news_id and 'zoom_id' in value and value['zoom_id'] == interest.zoom_id and value['name'] == interest.name:
+        if value['news_id'] == interest.news_id \
+            and 'zoom_id' in value and value['zoom_id'] == interest.zoom_id \
+            and value['name'] == interest.name:
             # news_id, zoom_id, nameが一致するデータが存在するなら、データを追加しない
             return {'status': 'ALREADY SETTLED'}
 

--- a/system/static/js/app.js
+++ b/system/static/js/app.js
@@ -170,7 +170,7 @@ var vmEnquete = new Vue({
               zoom_id: this.zoom_id,
               name: this.name,
               news_id: news.news_id,
-              degree: news.is_wanted ? 10 : 1,
+              degree: 10,
             })
             .then((response) => {
               `status: ${console.log(response.data.status)}`;

--- a/system/static/js/app.js
+++ b/system/static/js/app.js
@@ -135,6 +135,7 @@ var vmEnquete = new Vue({
   el: '#enquete',
   data: {
     news_list: [],
+    zoom_id: '',
     name: '',
     isAlert: false,
   },
@@ -153,6 +154,10 @@ var vmEnquete = new Vue({
   methods: {
     // 興味があるニュースを登録
     degreeSave: function () {
+      if (this.zoom_id.length === 0) {
+        window.alert('zoom idを入力してください');
+        return;
+      }
       if (this.name.length === 0) {
         window.alert('名前を入力してください');
         return;
@@ -162,6 +167,7 @@ var vmEnquete = new Vue({
         if (news.is_wanted === true) {
           axios
             .post('/api/save-degree', {
+              zoom_id: this.zoom_id,
               name: this.name,
               news_id: news.news_id,
               degree: news.is_wanted ? 10 : 1,

--- a/system/templates/enquete.html
+++ b/system/templates/enquete.html
@@ -10,6 +10,7 @@
   <body>
     [% include "html/header.html" %]
     <div id="enquete">
+      <h2>zoom idを入力してください: <input type="text" v-model="zoom_id" placeholder="xxx xxxx xxxx"></h2>
       <h2>名前を入力してください: <input type="text" v-model="name" placeholder="名前"></h2>
       <h2 v-model="newsQuestion">興味があるニュースページを選んでください</h2>
       <div id="wanted-news-list-wrapper">

--- a/system/utils/constructed_database.py
+++ b/system/utils/constructed_database.py
@@ -95,13 +95,13 @@ class Speech(Expression):
 class Interest(Expression):
 
     def __init__(self,
-            name: str, news_id: str, degree: int
+            name: str, news_id: str, degree: int, zoom_id: str
         ):
 
         if not 0 < degree <= 10:
             raise ValueError(f'degree must be in (0, 10]. <{degree=}>')
 
-        super().__init__(name, news_id, degree)
+        super().__init__(name, news_id, degree, zoom_id)
 
 
 


### PR DESCRIPTION
まだ動作が確認できていないため、Draftにしてあります。
動作確認のために、Firebaseのセキュリティルールから、`interest`に`zoom_id`のインデックスを作成して欲しいです。

## 関連issue
#27 

## やったこと
- /enqueteにzoom_idの入力フォームを用意し、興味のあるニュースと一緒にサーバーに送信する
- `/api/save-degree`の処理を変更
 news_id, zoom_id, nameが一致するデータが存在するなら、データを追加しない、存在しないならデータを追加する、という風にした
- `get_interest_df`関数を変更
  Firebaseの`interest`から、引数と一致するzoom_idを持つデータを取ってくる

## UI(スクショなどあれば)

## 備考
#29 とコンフリクトする

## 参考
- [データのインデックス作成](https://firebase.google.com/docs/database/security/indexing-data?hl=ja)
