### PR TITLE
興味のあるニュースの追加と更新処理を修正

### DIFF
--- a/system/app.py
+++ b/system/app.py
@@ -237,26 +237,21 @@ def api_save_degree():
     interest = Interest.from_dict(payload)
     print(f'{interest=}')
 
-    try:
-        interest_od = db.child('interest')\
-                .order_by_child('news_id')\
-                .equal_to(interest.news_id)\
-                .get().val()
+    interest_od = db.child('interest').get().val()
 
-    # ニュースがない場合は追加
-    except IndexError:
-        db.child('interest').push(interest.to_dict())
-        print('saving interest....')
+    for key, value in interest_od.items():
+        if value['name'] == interest.name and value['news_id'] == interest.news_id:
+            # 興味度を更新する
+            db.child('interest').child(key).update(interest.to_dict())
+            print('updating interest....')
 
-        return {'status': 'SAVED'}
+            return {'status': 'UPDATED'}
 
-    # ニュースがある場合は追加しない
-    else:
-        k = list(interest_od.keys())[0]
-        db.child('interest').child(k).update(interest.to_dict())
-        print('updating interest....')
+    # データを追加する
+    db.child('interest').push(interest.to_dict())
+    print('saving interest....')
 
-        return {'status': 'UPDATED'}
+    return {'status': 'SAVED'}
 
 
 @deco_api


### PR DESCRIPTION
## やったこと
- `/api/save-degree`の処理を、news_idとnameが一致するデータが存在しないならデータを追加、存在するなら興味度を更新するという風に修正しました。

## 備考
- Pyrebaseで複数カラムを検索する方法が分からなかったので、#26 と同様に、ordered dictの中のデータをfor文で全て見てチェックするというやり方をしています。
