### PR TITLE
/enqueteで表示するニュースの修正

### DIFF
--- a/system/app.py
+++ b/system/app.py
@@ -203,7 +203,13 @@ def api_save_news():
 def api_question_news():
     """ 人事によって選ばれた近日のニュースを提示 """
 
-    news_df = db.child('news').get().to_df()
+    zoom_id = request.args.get('zoom_id') # クエリパラメータからzoom_idを取得
+
+    # 該当のzoom_idに一致するニュースを検索
+    news_df = db.child('news')\
+                .order_by_child('zoom_id')\
+                .equal_to(zoom_id)\
+                .get().to_df()
     news_df['timestamp'] = pd.to_datetime(
             news_df['timestamp'],
             format='%y-%m-%d %H:%M:%S'

--- a/system/static/js/app.js
+++ b/system/static/js/app.js
@@ -147,13 +147,15 @@ var vmEnquete = new Vue({
   methods: {
     // 人事によって選ばれた近日のニュースを提示
     newsQuestion: function () {
-      axios.get(`/api/question-news?zoom_id=${this.zoom_id}`).then((response) => {
-        this.news_list = response.data.res;
-        console.log(this.news_list);
-        for (let i = 0; i < this.news_list.length; ++i) {
-          this.news_list[i].is_wanted = false;
-        }
-      });
+      axios
+        .get(`/api/question-news?zoom_id=${this.zoom_id}`)
+        .then((response) => {
+          this.news_list = response.data.res;
+          console.log(this.news_list);
+          for (let i = 0; i < this.news_list.length; ++i) {
+            this.news_list[i].is_wanted = false;
+          }
+        });
     },
     // 興味があるニュースを登録
     degreeSave: function () {

--- a/system/static/js/app.js
+++ b/system/static/js/app.js
@@ -139,14 +139,15 @@ var vmNews = new Vue({
 var vmEnquete = new Vue({
   el: '#enquete',
   data: {
+    zoom_id: '',
     news_list: [],
     name: '',
     isAlert: false,
   },
-  computed: {
+  methods: {
     // 人事によって選ばれた近日のニュースを提示
     newsQuestion: function () {
-      axios.get('/api/question-news').then((response) => {
+      axios.get(`/api/question-news?zoom_id=${this.zoom_id}`).then((response) => {
         this.news_list = response.data.res;
         console.log(this.news_list);
         for (let i = 0; i < this.news_list.length; ++i) {
@@ -154,8 +155,6 @@ var vmEnquete = new Vue({
         }
       });
     },
-  },
-  methods: {
     // 興味があるニュースを登録
     degreeSave: function () {
       if (this.name.length === 0) {

--- a/system/templates/enquete.html
+++ b/system/templates/enquete.html
@@ -10,16 +10,26 @@
   <body>
     [% include "html/header.html" %]
     <div id="enquete">
-      <h2>名前を入力してください<!-- <input type="text" v-model="name" placeholder="名前"> --></h2>
+      <h2>Zoom Meeting IDを入力してください</h2>
       <span>
-        <input class="balloon" id="name_text_style" type="text" v-model="name" placeholder="your name" autofocus /><label for="name_text_style">名前</label>
+        <input class="balloon" id="zoom_text_style" type="text" v-model="zoom_id" placeholder="xxx xxxx xxxx" autofocus maxlength="11" /><label for="zoom_text_style">Zoom ID</label>
       </span>
-      <h2 v-model="newsQuestion">興味があるニュースページを選んでください</h2>
-      <div id="wanted-news-list-wrapper">
-        <wanted-news-list v-for="news in news_list" :key="news.news_id" :news="news" @is_wanted="(is_wanted) => news.is_wanted=is_wanted"></wanted-news-list>
+      <br>
+      <div id="demo-button" @click="newsQuestion">
+        zoom idを送信
       </div>
-      <div id="demo-button" @click="degreeSave">
-        送信
+      <div v-if="news_list.length > 0">
+        <h2>名前を入力してください<!-- <input type="text" v-model="name" placeholder="名前"> --></h2>
+        <span>
+          <input class="balloon" id="name_text_style" type="text" v-model="name" placeholder="your name" autofocus /><label for="name_text_style">名前</label>
+        </span>
+        <h2 v-model="newsQuestion">興味があるニュースページを選んでください</h2>
+        <div id="wanted-news-list-wrapper">
+          <wanted-news-list v-for="news in news_list" :key="news.news_id" :news="news" @is_wanted="(is_wanted) => news.is_wanted=is_wanted"></wanted-news-list>
+        </div>
+        <div id="demo-button" @click="degreeSave">
+          送信
+        </div>
       </div>
     </div>
     [% include "html/footer.html" %]


### PR DESCRIPTION
## 関連issue
#9 

## やったこと
#15 と #26 の続きです。/enqueteでzoom idを入力し、送信ボタンを押すと、Firebaseの`news`から対応するzoom_idを持つニュースをフロントに返し表示するという風に修正しました。
`/api/question-news`はクエリパラメータを使うようにしています。例えば、/enqueteのzoom idのフォームに12345を入力すると、`/api/question-news?zoom_id=12345`にリクエストが飛び、Flask側で、`?zoom_id=12345`の部分から12345を取り出し検索を行う、ということをやっています。

## UI(スクショなどあれば)
https://user-images.githubusercontent.com/61813626/139519250-9b8af51a-481a-4618-b304-6043d02f1fe1.mov

## 参考資料
- [【Python】FlaskでHttpリクエストのパラメータを取得するには](https://migratory-worker.com/archives/4607)
